### PR TITLE
feat(client): validate bridge-issued client credentials

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "oauthclientbridge";
 
+  nixConfig = {
+    extra-substituters = ["https://oauthclientbridge.cachix.org"];
+    extra-trusted-public-keys = ["oauthclientbridge.cachix.org-1:j8sS8Vcj2imJiTxX76XwA1se5oRobp2j/mYgHbP6AKg="];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 

--- a/src/oauthclientbridge/client.py
+++ b/src/oauthclientbridge/client.py
@@ -1,0 +1,55 @@
+"""Bridge-issued client credentials, distinct from upstream OAuth handling.
+
+The `oauthclientbridge.oauth` package communicates with the configured OAuth
+provider. This module validates the client ID and secret issued by this bridge
+to its callers.
+"""
+
+from dataclasses import dataclass
+
+from oauthclientbridge import crypto, db, types
+
+
+@dataclass(frozen=True)
+class ClientCredentials:
+    client_id: types.ClientId
+    client_secret: types.ClientSecret
+
+
+class CredentialValidationError(ValueError):
+    pass
+
+
+class ClientIdValidationError(CredentialValidationError):
+    pass
+
+
+class ClientSecretValidationError(CredentialValidationError):
+    pass
+
+
+def validate_credentials(
+    client_id: str | None,
+    client_secret: str | None,
+) -> ClientCredentials:
+    if not client_id or not client_secret:
+        raise CredentialValidationError("Both client_id and client_secret must be set.")
+    if client_id == client_secret:
+        raise CredentialValidationError(
+            "client_id and client_secret set to same value."
+        )
+
+    try:
+        normalized_client_id = db.validate_client_id(client_id)
+    except ValueError as e:
+        raise ClientIdValidationError("Malformed client_id.") from e
+
+    try:
+        validated_client_secret = crypto.validate_key(client_secret)
+    except crypto.InvalidToken as e:
+        raise ClientSecretValidationError("Malformed client_secret.") from e
+
+    return ClientCredentials(
+        client_id=normalized_client_id,
+        client_secret=validated_client_secret,
+    )

--- a/src/oauthclientbridge/crypto.py
+++ b/src/oauthclientbridge/crypto.py
@@ -9,7 +9,7 @@ from oauthclientbridge import types
 InvalidToken = fernet.InvalidToken
 
 
-def _normalize_key_padding(key: str) -> str:
+def _normalize_base64_padding(key: str) -> str:
     if (remainder := len(key) % 4) in (2, 3):
         return key + ("=" * (4 - remainder))
     return key
@@ -22,11 +22,12 @@ def generate_key() -> types.ClientSecret:
 
 def validate_key(key: str) -> types.ClientSecret:
     """Validate an encoded Fernet key and mark it as a client secret."""
+    normalized_key = _normalize_base64_padding(key)
     try:
-        _ = fernet.Fernet(_normalize_key_padding(key).encode("ascii"))
+        _ = fernet.Fernet(normalized_key.encode("ascii"))
     except (ValueError, binascii.Error) as e:
         raise InvalidToken from e
-    return types.ClientSecret(key)
+    return types.ClientSecret(normalized_key)
 
 
 def dumps(key: types.ClientSecret, data: dict[str, Any]) -> types.EncryptedToken:
@@ -38,7 +39,7 @@ def dumps(key: types.ClientSecret, data: dict[str, Any]) -> types.EncryptedToken
 def loads(key: types.ClientSecret, token: types.EncryptedToken) -> dict[str, Any]:
     """Decrypts and verifies token with given key and calls json.loads."""
     try:
-        f = fernet.Fernet(_normalize_key_padding(key).encode("ascii"))
+        f = fernet.Fernet(_normalize_base64_padding(key).encode("ascii"))
     except (ValueError, binascii.Error) as e:
         raise InvalidToken from e
     return json.loads(f.decrypt(token).decode("utf-8"))

--- a/src/oauthclientbridge/crypto.py
+++ b/src/oauthclientbridge/crypto.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from cryptography import fernet
 
+from oauthclientbridge import types
+
 InvalidToken = fernet.InvalidToken
 
 
@@ -13,18 +15,27 @@ def _normalize_key_padding(key: str) -> str:
     return key
 
 
-def generate_key() -> str:
+def generate_key() -> types.ClientSecret:
     """Cryptographically safe key that is human readable."""
-    return fernet.Fernet.generate_key().decode("ascii")
+    return types.ClientSecret(fernet.Fernet.generate_key().decode("ascii"))
 
 
-def dumps(key: str, data: dict[str, Any]) -> bytes:
+def validate_key(key: str) -> types.ClientSecret:
+    """Validate an encoded Fernet key and mark it as a client secret."""
+    try:
+        _ = fernet.Fernet(_normalize_key_padding(key).encode("ascii"))
+    except (ValueError, binascii.Error) as e:
+        raise InvalidToken from e
+    return types.ClientSecret(key)
+
+
+def dumps(key: types.ClientSecret, data: dict[str, Any]) -> types.EncryptedToken:
     """Calls json.dumps on data and encrypts the result with given key."""
     f = fernet.Fernet(key.encode("ascii"))
-    return f.encrypt(json.dumps(data).encode("utf-8"))
+    return types.EncryptedToken(f.encrypt(json.dumps(data).encode("utf-8")))
 
 
-def loads(key: str, token: bytes) -> dict[str, Any]:
+def loads(key: types.ClientSecret, token: types.EncryptedToken) -> dict[str, Any]:
     """Decrypts and verifies token with given key and calls json.loads."""
     try:
         f = fernet.Fernet(_normalize_key_padding(key).encode("ascii"))

--- a/src/oauthclientbridge/db.py
+++ b/src/oauthclientbridge/db.py
@@ -10,7 +10,7 @@ from typing import Iterator
 from flask import current_app, g
 from opentelemetry import metrics, trace
 
-from oauthclientbridge import stats
+from oauthclientbridge import stats, types
 from oauthclientbridge.settings import current_settings
 from oauthclientbridge.utils import utcnow
 
@@ -32,18 +32,18 @@ _db_cursor_duration_histogram = meter.create_histogram(
 )
 
 
-def generate_id() -> str:
-    return str(uuid.uuid4())
+def generate_id() -> types.ClientId:
+    return types.ClientId(uuid.uuid4())
 
 
-def normalize_id(client_id: str) -> str:
-    return str(uuid.UUID(client_id))
+def validate_client_id(client_id: str) -> types.ClientId:
+    return types.ClientId(uuid.UUID(client_id))
 
 
 @dataclass(frozen=True)
 class TokenRecord:
-    client_id: str
-    encrypted_token: bytes | None
+    client_id: types.ClientId
+    encrypted_token: types.EncryptedToken | None
     created_at: datetime | None
     last_updated_at: datetime | None
 
@@ -160,7 +160,7 @@ def cursor(
             _db_cursor_total_counter.add(1, attributes=attributes)
 
 
-def _prepare_token(token: bytes | None) -> str | None:
+def _prepare_token(token: types.EncryptedToken | None) -> str | None:
     """Convert token to str so it gets stored as text type in sqlite3.
 
     This is primarily to make it nicer to inspect the DB when debugging as the
@@ -183,7 +183,7 @@ def _parse_datetime(value: object) -> datetime | None:
     return datetime.fromtimestamp(value, UTC)
 
 
-def insert(client_id: str, token: bytes) -> None:
+def insert(client_id: types.ClientId, token: types.EncryptedToken) -> None:
     """Store encrypted token and return what client_id it was stored under."""
 
     now = utcnow()
@@ -194,7 +194,7 @@ def insert(client_id: str, token: bytes) -> None:
                 "(client_id, token, created_at, last_updated_at) VALUES (?, ?, ?, ?)"
             ),
             (
-                client_id,
+                str(client_id),
                 _prepare_token(token),
                 _prepare_timestamp(now),
                 _prepare_timestamp(now),
@@ -204,7 +204,7 @@ def insert(client_id: str, token: bytes) -> None:
     stats.request_refresh()
 
 
-def lookup(client_id: str) -> TokenRecord:
+def lookup(client_id: types.ClientId) -> TokenRecord:
     """Lookup a client_id and return encrypted token plus metadata.
 
     Raises a LookupError if client_id is not found.
@@ -213,7 +213,7 @@ def lookup(client_id: str) -> TokenRecord:
     with cursor(name="lookup_token") as c:
         c.execute(
             "SELECT token, created_at, last_updated_at FROM tokens WHERE client_id = ?",
-            (client_id,),
+            (str(client_id),),
         )
         row = c.fetchone()
 
@@ -223,20 +223,22 @@ def lookup(client_id: str) -> TokenRecord:
     token_value = row[0]
     return TokenRecord(
         client_id=client_id,
-        encrypted_token=bytes(token_value) if token_value else None,
+        encrypted_token=types.EncryptedToken(bytes(token_value))
+        if token_value
+        else None,
         created_at=_parse_datetime(row[1]),
         last_updated_at=_parse_datetime(row[2]),
     )
 
 
-def update(client_id: str, token: bytes | None) -> int:
+def update(client_id: types.ClientId, token: types.EncryptedToken | None) -> int:
     """Update a client_id with a new encrypted token."""
 
     now = utcnow()
     with cursor(name="update_token", transaction=True) as c:
         c.execute(
             "UPDATE tokens SET token = ?, last_updated_at = ? WHERE client_id = ?",
-            (_prepare_token(token), _prepare_timestamp(now), client_id),
+            (_prepare_token(token), _prepare_timestamp(now), str(client_id)),
         )
         trace.get_current_span().add_event("Update result", {"rows": c.rowcount})
         rowcount = int(c.rowcount)

--- a/src/oauthclientbridge/db.py
+++ b/src/oauthclientbridge/db.py
@@ -36,6 +36,10 @@ def generate_id() -> str:
     return str(uuid.uuid4())
 
 
+def normalize_id(client_id: str) -> str:
+    return str(uuid.UUID(client_id))
+
+
 @dataclass(frozen=True)
 class TokenRecord:
     client_id: str

--- a/src/oauthclientbridge/telemetry.py
+++ b/src/oauthclientbridge/telemetry.py
@@ -2,6 +2,7 @@ import importlib.util
 from typing import assert_never
 
 import requests
+import structlog
 from flask import Flask
 from opentelemetry import trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
@@ -42,6 +43,7 @@ from opentelemetry.sdk.trace.export import (
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from requests.structures import CaseInsensitiveDict
 
+from oauthclientbridge import sentry
 from oauthclientbridge.resource_labels import (
     log_attributes,
     resource_attributes,
@@ -100,6 +102,19 @@ BYTE_BUCKETS = (
     204800,
     float("inf"),
 )
+
+
+def set_client_id(client_id: str) -> None:
+    """Associate a canonical client ID with the current request telemetry."""
+    structlog.contextvars.bind_contextvars(client_id=client_id)
+    trace.get_current_span().set_attribute("client_id", client_id)
+    sentry.set_user({"client_id": client_id})
+
+
+def record_invalid_client_id(client_id: str) -> None:
+    """Preserve the rejected input without treating it as a client identity."""
+    structlog.contextvars.bind_contextvars(invalid_client_id=client_id)
+    trace.get_current_span().add_event("invalid_client_id", {"client_id": client_id})
 
 
 def _requests_response_hook(

--- a/src/oauthclientbridge/telemetry.py
+++ b/src/oauthclientbridge/telemetry.py
@@ -43,7 +43,7 @@ from opentelemetry.sdk.trace.export import (
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from requests.structures import CaseInsensitiveDict
 
-from oauthclientbridge import sentry
+from oauthclientbridge import sentry, types
 from oauthclientbridge.resource_labels import (
     log_attributes,
     resource_attributes,
@@ -104,11 +104,12 @@ BYTE_BUCKETS = (
 )
 
 
-def set_client_id(client_id: str) -> None:
+def set_client_id(client_id: types.ClientId) -> None:
     """Associate a canonical client ID with the current request telemetry."""
-    structlog.contextvars.bind_contextvars(client_id=client_id)
-    trace.get_current_span().set_attribute("client_id", client_id)
-    sentry.set_user({"client_id": client_id})
+    client_id_string = str(client_id)
+    structlog.contextvars.bind_contextvars(client_id=client_id_string)
+    trace.get_current_span().set_attribute("client_id", client_id_string)
+    sentry.set_user({"client_id": client_id_string})
 
 
 def record_invalid_client_id(client_id: str) -> None:

--- a/src/oauthclientbridge/types.py
+++ b/src/oauthclientbridge/types.py
@@ -1,0 +1,6 @@
+import uuid
+from typing import NewType
+
+ClientId = NewType("ClientId", uuid.UUID)
+ClientSecret = NewType("ClientSecret", str)
+EncryptedToken = NewType("EncryptedToken", bytes)

--- a/src/oauthclientbridge/views.py
+++ b/src/oauthclientbridge/views.py
@@ -1,5 +1,4 @@
 import re
-import uuid
 from http import HTTPStatus
 from typing import Any
 
@@ -12,20 +11,13 @@ from opentelemetry.semconv.attributes.exception_attributes import (
     EXCEPTION_TYPE,
 )
 
-from oauthclientbridge import crypto, db, oauth, sentry, stats
+from oauthclientbridge import crypto, db, oauth, stats, telemetry
 from oauthclientbridge.errors import OAuthError
 from oauthclientbridge.settings import LogLevel, current_settings
 
 logger: structlog.BoundLogger = structlog.get_logger()
 
 routes = Blueprint("views", __name__)
-
-
-def _normalize_client_id(client_id: str) -> str:
-    try:
-        return str(uuid.UUID(client_id))
-    except ValueError:
-        raise oauth.Error(OAuthError.INVALID_CLIENT, "Malformed client_id.")
 
 
 @routes.route("/")
@@ -132,10 +124,7 @@ def callback() -> flask.Response:
     token = crypto.dumps(client_secret, result)
 
     client_id = db.generate_id()
-    # Keep client_id visible in logs/telemetry by design; it is an internal
-    # handle used for debugging and support, not an OAuth secret.
-    # TODO: Make this into telemetry.set_user and populate span attr?
-    sentry.set_user({"client_id": client_id})
+    telemetry.set_client_id(client_id)
 
     try:
         db.insert(client_id, token)
@@ -190,14 +179,13 @@ def token() -> flask.Response:
             "client_id and client_secret set to same value.",
         )
 
-    client_id = _normalize_client_id(client_id)
-
-    # TODO: Combine this in telemetry.set_user() that also does span...
-    # Keep client_id visible in logs/telemetry by design; it is an internal
-    # handle used for debugging and support, not an OAuth secret.
-    structlog.contextvars.bind_contextvars(client_id=client_id)
-    trace.get_current_span().set_attribute("client_id", client_id)
-    sentry.set_user({"client_id": client_id})
+    try:
+        client_id = db.normalize_id(client_id)
+    except ValueError:
+        telemetry.record_invalid_client_id(client_id)
+        raise oauth.Error(OAuthError.INVALID_CLIENT, "Malformed client_id.")
+    else:
+        telemetry.set_client_id(client_id)
 
     try:
         record = db.lookup(client_id)

--- a/src/oauthclientbridge/views.py
+++ b/src/oauthclientbridge/views.py
@@ -11,7 +11,7 @@ from opentelemetry.semconv.attributes.exception_attributes import (
     EXCEPTION_TYPE,
 )
 
-from oauthclientbridge import crypto, db, oauth, stats, telemetry
+from oauthclientbridge import client, crypto, db, oauth, stats, telemetry
 from oauthclientbridge.errors import OAuthError
 from oauthclientbridge.settings import LogLevel, current_settings
 
@@ -132,7 +132,9 @@ def callback() -> flask.Response:
         logger.warning("Could not get unique client id.")
         return _error("integrity_error", "Database integrity error.", client_state)
 
-    return _render(client_id=client_id, client_secret=client_secret, state=client_state)
+    return _render(
+        client_id=str(client_id), client_secret=client_secret, state=client_state
+    )
 
 
 @routes.route("/token", methods=["POST"])
@@ -157,35 +159,31 @@ def token() -> flask.Response:
     if authorization and authorization.type != "basic":
         raise oauth.Error(OAuthError.INVALID_CLIENT, "Only Basic Auth is supported.")
 
-    client_id: str | None = flask.request.form.get("client_id")
-    client_secret: str | None = flask.request.form.get("client_secret")
-    if (client_id or client_secret) and authorization:
+    client_id_value: str | None = flask.request.form.get("client_id")
+    client_secret_value: str | None = flask.request.form.get("client_secret")
+    if (client_id_value or client_secret_value) and authorization:
         raise oauth.Error(
             OAuthError.INVALID_REQUEST,
             "More than one mechanism for authenticating set.",
         )
     elif authorization:
-        client_id = authorization.username
-        client_secret = authorization.password
-
-    if not client_id or not client_secret:
-        raise oauth.Error(
-            OAuthError.INVALID_CLIENT,
-            "Both client_id and client_secret must be set.",
-        )
-    elif client_id == client_secret:
-        raise oauth.Error(
-            OAuthError.INVALID_CLIENT,
-            "client_id and client_secret set to same value.",
-        )
+        client_id_value = authorization.username
+        client_secret_value = authorization.password
 
     try:
-        client_id = db.normalize_id(client_id)
-    except ValueError:
-        telemetry.record_invalid_client_id(client_id)
+        credentials = client.validate_credentials(client_id_value, client_secret_value)
+    except client.ClientIdValidationError:
+        telemetry.record_invalid_client_id(client_id_value)
         raise oauth.Error(OAuthError.INVALID_CLIENT, "Malformed client_id.")
+    except client.ClientSecretValidationError:
+        raise oauth.Error(OAuthError.INVALID_CLIENT, "Client not known.")
+    except client.CredentialValidationError as e:
+        raise oauth.Error(OAuthError.INVALID_CLIENT, str(e))
     else:
-        telemetry.set_client_id(client_id)
+        telemetry.set_client_id(credentials.client_id)
+
+    client_id = credentials.client_id
+    client_secret = credentials.client_secret
 
     try:
         record = db.lookup(client_id)

--- a/src/oauthclientbridge/views.py
+++ b/src/oauthclientbridge/views.py
@@ -322,7 +322,7 @@ def _error(
     )
     current_span.add_event(
         "error",
-        {EXCEPTION_MESSAGE: description or "", EXCEPTION_TYPE: error_code},
+        {EXCEPTION_MESSAGE: f"{error_code}: {description}", EXCEPTION_TYPE: error_code},
     )
 
     stats.ServerErrorCounter.labels(

--- a/src/oauthclientbridge/views.py
+++ b/src/oauthclientbridge/views.py
@@ -173,7 +173,8 @@ def token() -> flask.Response:
     try:
         credentials = client.validate_credentials(client_id_value, client_secret_value)
     except client.ClientIdValidationError:
-        telemetry.record_invalid_client_id(client_id_value)
+        if client_id_value is not None:
+            telemetry.record_invalid_client_id(client_id_value)
         raise oauth.Error(OAuthError.INVALID_CLIENT, "Malformed client_id.")
     except client.ClientSecretValidationError:
         raise oauth.Error(OAuthError.INVALID_CLIENT, "Client not known.")

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,0 +1,42 @@
+import uuid
+
+import pytest
+
+from oauthclientbridge import client, crypto, types
+
+
+def test_validate_credentials_returns_typed_credentials() -> None:
+    client_secret = crypto.generate_key()
+    credentials = client.validate_credentials(
+        "00000000-0000-0000-0000-000000000001", client_secret
+    )
+
+    assert credentials.client_id == types.ClientId(
+        uuid.UUID("00000000-0000-0000-0000-000000000001")
+    )
+    assert credentials.client_secret == client_secret
+
+
+@pytest.mark.parametrize(
+    ("client_id", "client_secret", "error_type", "message"),
+    [
+        (None, "secret", client.CredentialValidationError, "Both client_id"),
+        ("client", None, client.CredentialValidationError, "Both client_id"),
+        ("same", "same", client.CredentialValidationError, "set to same value"),
+        ("malformed", "secret", client.ClientIdValidationError, "Malformed client_id"),
+        (
+            "00000000-0000-0000-0000-000000000001",
+            "not-a-fernet-key",
+            client.ClientSecretValidationError,
+            "Malformed client_secret",
+        ),
+    ],
+)
+def test_validate_credentials_rejects_invalid_values(
+    client_id: str | None,
+    client_secret: str | None,
+    error_type: type[ValueError],
+    message: str,
+) -> None:
+    with pytest.raises(error_type, match=message):
+        _ = client.validate_credentials(client_id, client_secret)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from flask.testing import FlaskClient
 from pydantic import SecretStr
 from werkzeug.datastructures import Headers
 
-from oauthclientbridge import create_app, crypto, db
+from oauthclientbridge import create_app, crypto, db, types
 from oauthclientbridge.oauth import retry as oauth_retry
 from oauthclientbridge.settings import (
     DatabaseSettings,
@@ -44,8 +44,8 @@ class ResponseTuple(NamedTuple):
 
 
 class TokenTuple(NamedTuple):
-    client_id: str
-    client_secret: str
+    client_id: types.ClientId
+    client_secret: types.ClientSecret
     value: dict[str, Any]
 
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -3,6 +3,18 @@ import pytest
 from oauthclientbridge import crypto
 
 
+def test_validate_key_accepts_padded_and_unpadded_fernet_keys():
+    key = crypto.generate_key()
+
+    assert crypto.validate_key(key) == key
+    assert crypto.validate_key(key.rstrip("=")) == key.rstrip("=")
+
+
+def test_validate_key_rejects_malformed_key():
+    with pytest.raises(crypto.InvalidToken):
+        _ = crypto.validate_key("not-a-fernet-key")
+
+
 def test_loads_rejects_client_secret_with_impossible_base64_padding():
     token = crypto.dumps(crypto.generate_key(), {"access_token": "123"})
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -7,7 +7,7 @@ def test_validate_key_accepts_padded_and_unpadded_fernet_keys():
     key = crypto.generate_key()
 
     assert crypto.validate_key(key) == key
-    assert crypto.validate_key(key.rstrip("=")) == key.rstrip("=")
+    assert crypto.validate_key(key.rstrip("=")) == key
 
 
 def test_validate_key_rejects_malformed_key():

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from unittest.mock import patch
@@ -5,6 +6,24 @@ from unittest.mock import patch
 import pytest
 
 from oauthclientbridge import db
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000000000000000000000000001",
+    ],
+)
+def test_validate_client_id(value: str) -> None:
+    assert db.validate_client_id(value) == uuid.UUID(
+        "00000000-0000-0000-0000-000000000001"
+    )
+
+
+def test_validate_client_id_rejects_malformed_value() -> None:
+    with pytest.raises(ValueError, match="badly formed"):
+        _ = db.validate_client_id("not-a-uuid")
 
 
 @dataclass(frozen=True)

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -164,7 +164,7 @@ def test_metrics_exposes_token_grant_age_histogram_for_successful_token_use(
     created_at = int((datetime.now(UTC) - timedelta(days=200)).timestamp())
     _ = cursor.execute(
         "UPDATE tokens SET created_at = ? WHERE client_id = ?",
-        (created_at, access_token.client_id),
+        (created_at, str(access_token.client_id)),
     )
 
     observed: list[float] = []
@@ -196,7 +196,7 @@ def test_metrics_skips_token_grant_age_histogram_for_unknown_age(
 ):
     _ = cursor.execute(
         "UPDATE tokens SET created_at = NULL WHERE client_id = ?",
-        (access_token.client_id,),
+        (str(access_token.client_id),),
     )
 
     observed: list[float] = []

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -230,7 +230,7 @@ def test_local_invalid_grant_records_handled_trace_error(
     request_span = otel.get_span(spans, "POST /token")
     assert request_span is not None
     assert request_span.attributes is not None
-    assert request_span.attributes["client_id"] == access_token.client_id
+    assert request_span.attributes["client_id"] == str(access_token.client_id)
     assert request_span.attributes["error.unhandled"] is False
     assert request_span.attributes["oauth.error"] == "invalid_grant"
     assert request_span.status.status_code == trace.StatusCode.ERROR

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -237,6 +237,49 @@ def test_local_invalid_grant_records_handled_trace_error(
     assert any(event.name == "exception" for event in request_span.events)
 
 
+def test_malformed_client_id_records_rejected_value(
+    otel_mock: otel.OTelMocker,
+    post: PostClient,
+) -> None:
+    malformed_client_id = "# SPOTIFY_CLIENT_ID"
+
+    response = post(
+        "/token",
+        {
+            "client_id": malformed_client_id,
+            "client_secret": "secret",
+            "grant_type": "client_credentials",
+        },
+    )
+
+    assert response.status == HTTPStatus.UNAUTHORIZED
+
+    spans = otel_mock.get_finished_spans()
+    request_span = otel.get_span(spans, "POST /token")
+    assert request_span is not None
+    invalid_client_id_event = next(
+        event for event in request_span.events if event.name == "invalid_client_id"
+    )
+    assert invalid_client_id_event.attributes["client_id"] == malformed_client_id
+
+
+def test_callback_missing_state_records_trace_error_message(
+    otel_mock: otel.OTelMocker,
+    get: GetClient,
+) -> None:
+    response = get("/callback?code=1234")
+
+    assert response.status == 400
+    assert response.data["error"] == OAuthError.INVALID_STATE
+
+    spans = otel_mock.get_finished_spans()
+    request_span = otel.get_span(spans, "GET /callback")
+    assert request_span is not None
+
+    error_event = next(event for event in request_span.events if event.name == "error")
+    assert error_event.attributes["exception.message"].startswith("invalid_state:")
+
+
 def test_unhandled_server_error_marks_span_unhandled(
     otel_mock: otel.OTelMocker,
     client: FlaskClient,

--- a/tests/token_test.py
+++ b/tests/token_test.py
@@ -175,7 +175,7 @@ def test_token_normalizes_dashless_uuid_client_id(
     post: PostClient, access_token: TokenTuple
 ):
     data = {
-        "client_id": access_token.client_id.replace("-", ""),
+        "client_id": str(access_token.client_id).replace("-", ""),
         "client_secret": access_token.client_secret,
         "grant_type": "client_credentials",
     }


### PR DESCRIPTION
- Reject malformed client IDs and invalid client secrets before token processing.
- Centralize client-ID telemetry across logs, traces, and Sentry using canonical IDs.
- Preserve rejected client-ID values in telemetry without treating them as authenticated identities.
- Standardize OAuth trace error messages for clearer diagnostics.
- Add credential-validation and telemetry coverage.
- Add stricter typing for `ClientId`, `ClientSecret` and `EncryptedToken`